### PR TITLE
Add `try_filter_map_results` method.

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1159,6 +1159,55 @@ impl<I, F, T, U, E> Iterator for MapResults<I, F>
     }
 }
 
+/// An iterator adapter to apply a fallible transformation within a nested `Result`.
+///
+/// See [`.try_map_results()`](../trait.Itertools.html#method.try_map_results) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct TryMapResults<I, F> {
+    iter: I,
+    f: F
+}
+
+/// Create a new `TryMapResults` iterator.
+pub fn try_map_results<I, F, T, U, E>(iter: I, f: F) -> TryMapResults<I, F>
+    where I: Iterator<Item = Result<T, E>>,
+          F: FnMut(T) -> Result<U, E>
+{
+    TryMapResults {
+        iter: iter,
+        f: f,
+    }
+}
+
+impl<I, F, T, U, E> Iterator for TryMapResults<I, F>
+    where I: Iterator<Item = Result<T, E>>,
+          F: FnMut(T) -> Result<U, E>
+{
+    type Item = Result<U, E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|v| v.and_then(&mut self.f))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    fn fold<Acc, Fold>(self, init: Acc, mut fold_f: Fold) -> Acc
+        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.iter.fold(init, move |acc, v| fold_f(acc, v.and_then(&mut f)))
+    }
+
+    fn collect<C>(self) -> C
+        where C: FromIterator<Self::Item>
+    {
+        let mut f = self.f;
+        self.iter.map(move |v| v.and_then(&mut f)).collect()
+    }
+}
+
 /// An iterator adapter to get the positions of each element that matches a predicate.
 ///
 /// See [`.positions()`](../trait.Itertools.html#method.positions) for more information.

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1249,7 +1249,7 @@ impl<I, F, T, U, E> Iterator for TryFilterMapResults<I, F>
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        (0, self.iter.size_hint().1)
     }
 
     fn fold<Acc, Fold>(self, init: Acc, mut fold_f: Fold) -> Acc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod structs {
         Batching,
         Step,
         MapResults,
+        TryMapResults,
         Merge,
         MergeBy,
         TakeWhileRef,
@@ -633,6 +634,24 @@ pub trait Itertools : Iterator {
               F: FnMut(T) -> U,
     {
         adaptors::map_results(self, f)
+    }
+
+    /// Return an iterator adaptor that applies the provided fallible
+    /// closure to every `Result::Ok` value. `Result::Err` values in
+    /// the original iterator are unchanged.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let input = vec![Ok(41), Err(false), Ok(i32::max_value())];
+    /// let it = input.into_iter().try_map_results(|i| i.checked_add(1).ok_or(true));
+    /// itertools::assert_equal(it, vec![Ok(42), Err(false), Err(true)]);
+    /// ```
+    fn try_map_results<F, T, U, E>(self, f: F) -> TryMapResults<Self, F>
+        where Self: Iterator<Item = Result<T, E>> + Sized,
+              F: FnMut(T) -> Result<U, E>,
+    {
+        adaptors::try_map_results(self, f)
     }
 
     /// Return an iterator adaptor that merges the two base iterators in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod structs {
         Batching,
         Step,
         MapResults,
+        TryFilterMapResults,
         TryMapResults,
         Merge,
         MergeBy,
@@ -652,6 +653,24 @@ pub trait Itertools : Iterator {
               F: FnMut(T) -> Result<U, E>,
     {
         adaptors::try_map_results(self, f)
+    }
+
+    /// Return an iterator adaptor that filters and transforms every
+    /// `Result::Ok` value with the provided fallible closure.
+    /// `Result::Err` values in the original iterator are unchanged.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let input = vec![Ok(11), Ok(41), Err(false), Ok(i32::max_value())];
+    /// let it = input.into_iter().try_filter_map_results(|i| if i > 20 { Some(i.checked_add(1).ok_or(true)).transpose() } else { Ok(None) });
+    /// itertools::assert_equal(it, vec![Ok(42), Err(false), Err(true)]);
+    /// ```
+    fn try_filter_map_results<F, T, U, E>(self, f: F) -> TryFilterMapResults<Self, F>
+        where Self: Iterator<Item = Result<T, E>> + Sized,
+              F: FnMut(T) -> Result<Option<U>, E>,
+    {
+        adaptors::try_filter_map_results(self, f)
     }
 
     /// Return an iterator adaptor that merges the two base iterators in


### PR DESCRIPTION
You may wanna hold off merging this until https://github.com/rust-itertools/itertools/pull/377#issuecomment-547435270 (compatibility with Rust 1.24) is resolved. This commit also uses `{Option,Result}::transpose()`, which is not available in that version.